### PR TITLE
v5.3.4 - OutFile improvements

### DIFF
--- a/tests/teardown.dyalog
+++ b/tests/teardown.dyalog
@@ -1,4 +1,0 @@
-﻿ r←teardown dummy
-⍝ teardown DRC and Conga
- r←''
- {}#.⎕EX'DRC' 'Conga' 'HttpCommand' 'httpcommand_test'

--- a/tests/test_outfile.aplf
+++ b/tests/test_outfile.aplf
@@ -12,20 +12,24 @@
  ⎕NUNTIE tn
  h←#.HttpCommand.New'get' 'dyalog.com'
  resp←h.Run
+ →Cleanup if notEmpty r←(0 200≢resp.(rc HttpStatus))/⍕resp
  data←resp.Data ⍝ note size of data
  h.OutFile←fname
  resp←h.Run
+ →Cleanup if notEmpty r←(0 200≢resp.(rc HttpStatus))/⍕resp
  →Cleanup if notEmpty r←(data≢readFile fname)/'OutFile data does not match reference data'
  →Cleanup if notEmpty r←(resp.BytesWritten≠fileSize fname)/'File size does not match BytesWritten'
  resp←h.Run
  →Cleanup if notEmpty r←((resp.rc=¯1)⍲resp.msg contains'not empty')/'Error in overwrite protection'
  h.OutFile←fname 1 ⍝ overwrite file
  resp←h.Run
+ →Cleanup if notEmpty r←(0 200≢resp.(rc HttpStatus))/⍕resp
  →Cleanup if notEmpty r←(data≢readFile fname)/'Overwrite OutFile data does not match reference data'
  →Cleanup if notEmpty r←(resp.BytesWritten≠fileSize fname)/'Overwrite file size does not match BytesWritten'
  h.OutFile←fname 2 ⍝ append to file
  size←fileSize fname
  resp←h.Run
+ →Cleanup if notEmpty r←(0 200≢resp.(rc HttpStatus))/⍕resp
  →Cleanup if notEmpty r←((data⍴⍨2×⍴data)≢readFile fname)/'Append OutFile data does not match reference data'
  →Cleanup if notEmpty r←((size+resp.BytesWritten)≠fileSize fname)/'Append file size does not match previous size + BytesWritten'
 Cleanup:

--- a/tests/test_outfile.aplf
+++ b/tests/test_outfile.aplf
@@ -1,0 +1,33 @@
+ {r}←test_outfile dummy;tmp;tn;fname;h;resp;fileSize;if;notEmpty;contains;nnums;data;size;readFile
+ nnums←⎕NNUMS
+ if←⍴⍨
+ notEmpty←~∘(0∘∊)∘≢
+ contains←(∨/)⍷⍨
+ fileSize←{⊃2 ⎕NINFO ⍵}
+ readFile←{tn←⍵ ⎕NTIE 0 ⋄ (⎕NUNTIE tn)⊢'UTF-8'⎕UCS ⎕UCS ⎕NREAD tn,(⎕DR''),2↑⎕NSIZE tn}
+ r←''
+ tmp←739⌶0 ⍝ temporary folder
+ tn←(tmp,'/outfile-test')(⎕NCREATE ⎕OPT'Unique' 1)0 ⍝ unique file
+ fname←(⎕NNUMS⍳tn)⊃↓⎕NNAMES ⍝ get its name
+ ⎕NUNTIE tn
+ h←#.HttpCommand.New'get' 'dyalog.com'
+ resp←h.Run
+ data←resp.Data ⍝ note size of data
+ h.OutFile←fname
+ resp←h.Run
+ →Cleanup if notEmpty r←(data≢readFile fname)/'OutFile data does not match reference data'
+ →Cleanup if notEmpty r←(resp.BytesWritten≠fileSize fname)/'File size does not match BytesWritten'
+ resp←h.Run
+ →Cleanup if notEmpty r←((resp.rc=¯1)⍲resp.msg contains'not empty')/'Error in overwrite protection'
+ h.OutFile←fname 1 ⍝ overwrite file
+ resp←h.Run
+ →Cleanup if notEmpty r←(data≢readFile fname)/'Overwrite OutFile data does not match reference data'
+ →Cleanup if notEmpty r←(resp.BytesWritten≠fileSize fname)/'Overwrite file size does not match BytesWritten'
+ h.OutFile←fname 2 ⍝ append to file
+ size←fileSize fname
+ resp←h.Run
+ →Cleanup if notEmpty r←((data⍴⍨2×⍴data)≢readFile fname)/'Append OutFile data does not match reference data'
+ →Cleanup if notEmpty r←((size+resp.BytesWritten)≠fileSize fname)/'Append file size does not match previous size + BytesWritten'
+Cleanup:
+ ⎕NUNTIE ⎕NNUMS~nnums
+ ⎕NDELETE fname


### PR DESCRIPTION
When writing response payload to file:

- unzip compressed response payload
- use a temporary file for intermediate operations then append to output file
- consolidate duplicate code for OutFile and non-OutFile handling
- write test_outfile